### PR TITLE
fix Fosc lilypondVersion

### DIFF
--- a/classes/base/Fosc.sc
+++ b/classes/base/Fosc.sc
@@ -14,7 +14,7 @@ Fosc {
     *lilypondVersion {
         var str;
         str = "% --version".format(this.lilypondPath).unixCmdGetStdOut;
-        str = str.copyRange(*[str.findRegexp("\\s[0-9]")[0][0]+1, str.find("\n") - 1]);
+        str = str.copyRange(*[str.findRegexp("\\s[0-9]")[0][0]+1, min(str.find("\n"), str.find(" (")?99) - 1]);
         ^str;
     }
     /* --------------------------------------------------------------------------------------------------------

--- a/classes/base/Fosc.sc
+++ b/classes/base/Fosc.sc
@@ -54,7 +54,7 @@ Fosc {
     Fosc.rootDirectory;
     -------------------------------------------------------------------------------------------------------- */
     *rootDirectory {
-        ^"%/fosc".format(Platform.userExtensionDir);
+        ^Fosc.filenameSymbol.asString.dirname.dirname.dirname;
     }
     /* --------------------------------------------------------------------------------------------------------
     • *stylesheetDirectory


### PR DESCRIPTION
removes the text after the version. else it'll end up in the .ly file and won't compile.

lilypond --version
GNU LilyPond 2.24.1 (running Guile 2.2)

unsure if the additional text is new in 2.24 or if it's an addition by MacPorts.