### PR TITLE
Add Windows support, Mac (silicon) support and suppress misleading error messages

### DIFF
--- a/classes/base/Fosc.sc
+++ b/classes/base/Fosc.sc
@@ -9,13 +9,30 @@ Fosc {
     classvar <tuning;
     classvar <>xmlVersion="4.0";
     /* --------------------------------------------------------------------------------------------------------
-    • *lilypondVersion
+    • *crossPlatformPath
     
+    Fosc.crossPlatformPath;
+    -------------------------------------------------------------------------------------------------------- */
+        *crossPlatformPath { |path|
+        ^Platform.case(
+            \linux,   { path.shellQuote },
+            \osx,     { path.shellQuote },
+			\windows, { if(path.contains(" ")) {
+				"\"" ++ path.replace($\\, $/) ++ "\""
+			} {
+				path.replace($\\, $/)
+			}
+		}
+        );
+	}
+    /* --------------------------------------------------------------------------------------------------------
+    • *lilypondVersion
+
     Fosc.lilypondVersion;
     -------------------------------------------------------------------------------------------------------- */
     *lilypondVersion {
         var str;
-        str = "% --version".format(this.lilypondPath).unixCmdGetStdOut;
+        str = "% --version".format(this.crossPlatformPath(lilypondPath)).unixCmdGetStdOut;
         str = str.copyRange(*[str.findRegexp("\\s[0-9]")[0][0]+1, min(str.find("\n"), str.find(" (")?99) - 1]);
         ^str;
     }
@@ -25,11 +42,11 @@ Fosc {
     Fosc.lilypondPath;
     -------------------------------------------------------------------------------------------------------- */ 
     *lilypondPath {
-        if (lilypondPath.isNil || { File.exists(lilypondPath).not }) {
-            error("LilyPond executable not found at: %.".format(lilypondPath));
+        if (lilypondPath.isNil || { File.exists(crossPlatformPath(lilypondPath)).not }) {
+            error("LilyPond executable not found at: %.".format(crossPlatformPath(lilypondPath)));
             ^nil;
         } {
-            ^lilypondPath;  
+            ^crossPlatformPath(lilypondPath);
         };
     }
     /* --------------------------------------------------------------------------------------------------------

--- a/classes/base/Fosc.sc
+++ b/classes/base/Fosc.sc
@@ -17,13 +17,8 @@ Fosc {
         ^Platform.case(
             \linux,   { path.shellQuote },
             \osx,     { path.shellQuote },
-			\windows, { if(path.contains(" ")) {
-				"\"" ++ path.replace($\\, $/) ++ "\""
-			} {
-				path.replace($\\, $/)
-			}
-		}
-        );
+			\windows, { "\"" ++ path.replace("\\", "/") ++ "\"" }
+        )
 	}
     /* --------------------------------------------------------------------------------------------------------
     • *lilypondVersion

--- a/classes/base/Fosc.sc
+++ b/classes/base/Fosc.sc
@@ -13,7 +13,7 @@ Fosc {
     
     Fosc.crossPlatformPath;
     -------------------------------------------------------------------------------------------------------- */
-        *crossPlatformPath { |path|
+    *crossPlatformPath { |path|
         ^Platform.case(
             \linux,   { path.shellQuote },
             \osx,     { path.shellQuote },
@@ -37,11 +37,11 @@ Fosc {
     Fosc.lilypondPath;
     -------------------------------------------------------------------------------------------------------- */ 
     *lilypondPath {
-        if (lilypondPath.isNil || { File.exists(crossPlatformPath(lilypondPath)).not }) {
-            error("LilyPond executable not found at: %.".format(crossPlatformPath(lilypondPath)));
+        if (lilypondPath.isNil || { File.exists(lilypondPath).not }) {
+            error("LilyPond executable not found at: %.".format(lilypondPath));
             ^nil;
         } {
-            ^crossPlatformPath(lilypondPath);
+            ^lilypondPath;  
         };
     }
     /* --------------------------------------------------------------------------------------------------------

--- a/classes/system/FoscIOManager.sc
+++ b/classes/system/FoscIOManager.sc
@@ -137,17 +137,52 @@ FoscIOManager : Fosc {
     FoscIOManager.runLilypond("%/0001.ly".format(Fosc.outputDirectory));
     -------------------------------------------------------------------------------------------------------- */
     *runLilypond { |path, flags, outputPath, executablePath, clean=false|
-        var lilypondBase, command, exitCode, success;
-        
-        executablePath = executablePath ?? { Fosc.lilypondPath };
-        lilypondBase = path.splitext[0];
-        outputPath = outputPath ? lilypondBase;
-        flags = ((flags ? "") ++ " %").format("-dno-point-and-click -o");
-        command = "% % % %".format(executablePath, flags, outputPath.shellQuote, path.shellQuote);
-        exitCode = systemCmd(command);
-        success = (exitCode == 0);
-        if (success && clean) { File.delete(path) };
-        
-        ^success;
-    }
+		var lilypondBase, command, exitCode, success;
+		var filterGrep, filterFindstr, commandWithFilterText;
+
+		executablePath = executablePath ?? { lilypondPath };
+		lilypondBase = path.splitext[0];
+		outputPath = outputPath ? lilypondBase;
+
+		flags = ((flags ? "") ++ " %").format("-dno-point-and-click -o");
+
+		filterGrep = "2>&1 | grep -vE " ++
+		"'^(Processing|Parsing\\.\\.\\.|Interpreting music\\.\\.\\.|" ++
+		"Preprocessing graphical objects\\.\\.\\.|" ++
+		"Finding the ideal number of pages\\.\\.\\.|" ++
+		"Fitting music on [0-9]+ page[s]?\\.\\.\\.|Drawing systems\\.\\.\\.|" ++
+		"Converting to .+)$' | " ++
+		"grep -vE '^$'";
+
+		filterFindstr = "2>&1" ++
+		" | findstr /V /R /C:\"^Processing$\"" ++
+		" | findstr /V /R /C:\"^Parsing\\.\\.\\.$\"" ++
+		" | findstr /V /R /C:\"^Interpreting music\\.\\.\\.$\"" ++
+		" | findstr /V /R /C:\"^Preprocessing graphical objects\\.\\.\\.$\"" ++
+		" | findstr /V /R /C:\"^Finding the ideal number of pages\\.\\.\\.$\"" ++
+		" | findstr /V /R /C:\"^Fitting music on [0-9][0-9]* page[s]*\\.\\.\\.$\"" ++
+		" | findstr /V /R /C:\"^Drawing systems\\.\\.\\.$\"" ++
+		" | findstr /V /R /C:\"^Converting to .*$\"" ++
+		" | findstr /V /R /C:\"^$\"";
+
+		command = "% % % %".format(
+			Fosc.crossPlatformPath(executablePath),
+			flags,
+			Fosc.crossPlatformPath(outputPath),
+			Fosc.crossPlatformPath(path)
+		);
+
+		commandWithFilterText = Platform.case(
+			\linux,   { command + filterGrep },
+			\osx,     { command + filterGrep },
+			\windows, { Fosc.crossPlatformPath(command + filterFindstr) }
+		);
+
+		command.postln;
+		exitCode = systemCmd(commandWithFilterText);
+		success = (exitCode == 0);
+		if (success && clean) { File.delete(path) };
+
+		^success;
+	}
 }

--- a/classes/system/FoscIOManager.sc
+++ b/classes/system/FoscIOManager.sc
@@ -154,16 +154,16 @@ FoscIOManager : Fosc {
 		"Converting to .+)$' | " ++
 		"grep -vE '^$'";
 
-		filterFindstr = "2>&1" ++
-		" | findstr /V /R /C:\"^Processing$\"" ++
-		" | findstr /V /R /C:\"^Parsing\\.\\.\\.$\"" ++
-		" | findstr /V /R /C:\"^Interpreting music\\.\\.\\.$\"" ++
-		" | findstr /V /R /C:\"^Preprocessing graphical objects\\.\\.\\.$\"" ++
-		" | findstr /V /R /C:\"^Finding the ideal number of pages\\.\\.\\.$\"" ++
-		" | findstr /V /R /C:\"^Fitting music on [0-9][0-9]* page[s]*\\.\\.\\.$\"" ++
-		" | findstr /V /R /C:\"^Drawing systems\\.\\.\\.$\"" ++
-		" | findstr /V /R /C:\"^Converting to .*$\"" ++
-		" | findstr /V /R /C:\"^$\"";
+		filterFindstr = "2>&1" +
+		"| findstr /V /R /C:\"^Processing$\"" +
+		"| findstr /V /R /C:\"^Parsing\\.\\.\\.$\"" +
+		"| findstr /V /R /C:\"^Interpreting music\\.\\.\\.$\"" +
+		"| findstr /V /R /C:\"^Preprocessing graphical objects\\.\\.\\.$\"" +
+		"| findstr /V /R /C:\"^Finding the ideal number of pages\\.\\.\\.$\"" +
+		"| findstr /V /R /C:\"^Fitting music on [0-9][0-9]* page[s]*\\.\\.\\.$\"" +
+		"| findstr /V /R /C:\"^Drawing systems\\.\\.\\.$\"" +
+		"| findstr /V /R /C:\"^Converting to .*$\"" +
+		"| findstr /V /R /C:\"^$\"";
 
 		command = "% % % %".format(
 			Fosc.crossPlatformPath(executablePath),
@@ -178,7 +178,6 @@ FoscIOManager : Fosc {
 			\windows, { Fosc.crossPlatformPath(command + filterFindstr) }
 		);
 
-		command.postln;
 		exitCode = systemCmd(commandWithFilterText);
 		success = (exitCode == 0);
 		if (success && clean) { File.delete(path) };

--- a/classes/system/FoscIOManager.sc
+++ b/classes/system/FoscIOManager.sc
@@ -174,7 +174,12 @@ FoscIOManager : Fosc {
 
 		commandWithFilterText = Platform.case(
 			\linux,   { command + filterGrep },
-			\osx,     { command + filterGrep },
+			\osx,     { if(Fosc.lilypondPath.contains("homebrew")) {
+					"zsh -lc" + (command + filterGrep).shellQuote
+				}{
+					command + filterGrep
+				}
+			},
 			\windows, { Fosc.crossPlatformPath(command + filterFindstr) }
 		);
 

--- a/classes/system/FoscIOManager.sc
+++ b/classes/system/FoscIOManager.sc
@@ -144,7 +144,7 @@ FoscIOManager : Fosc {
 		lilypondBase = path.splitext[0];
 		outputPath = outputPath ? lilypondBase;
 
-		flags = ((flags ? "") ++ " %").format("-dno-point-and-click -o");
+		flags = ((flags ? "") ++ "%").format("-dno-point-and-click -o");
 
 		filterGrep = "2>&1 | grep -vE " ++
 		"'^(Processing|Parsing\\.\\.\\.|Interpreting music\\.\\.\\.|" ++


### PR DESCRIPTION
Closes #9  
Fixes #3, #7 and #8

As of mid-April 2026, `Fosc` still had three outstanding issues:

- it did not work on ARM64 Mac when using LilyPond 2.24.4 installed via Homebrew;
- it did not support Windows; and
- it printed unnecessary messages prefixed with `ERROR`.

This PR addresses all of them.

When I originally opened #9, I had not yet found a workable way to support Windows. I have now implemented and tested a solution that enables `Fosc` to run on Windows.

There was also some overlap between #9 and another PR relating to Windows compatibility and Silicon Mac compatibility, so I have consolidated the relevant changes here for clarity.

The implementation uses `Platform.case` to handle platform-specific behaviour. I appreciate that this may not be everyone's preferred approach, and I would welcome a cleaner or more elegant alternative if one is available. However, to the best of my knowledge, this is currently the most practical solution I can provide, and it works reliably in practice.

If there is no preference for a different implementation strategy, I hope this PR may be suitable for review and eventual merge.
